### PR TITLE
Routed consumer-scope JWT auth to the global app host while keeping the JWT workspace claim configurable

### DIFF
--- a/js/src/constants.ts
+++ b/js/src/constants.ts
@@ -6,6 +6,7 @@ export const TLD: Record<string, string> = {
 
 export const USER_LOGIN_PATH = "/users/auth/jwt";
 export const CONSUMER_LOGIN_PATH = "/consumers/auth/jwt";
+export const CONSUMER_WORKSPACE = "app";
 
 export const NEETO_URL_COMPONENT_REGEX = /neeto(\w+)/;
 export const NEETO_URL_PREFIX_REGEX = /^(https?:\/\/)?(www\.)?[\w-]+\./;

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -1,4 +1,5 @@
 import jwt from "jsonwebtoken";
+import { CONSUMER_WORKSPACE } from "./constants.js";
 import type { Scope } from "./types.js";
 import {
   getClientAppName,
@@ -13,8 +14,6 @@ interface Options {
   privateKey?: string;
   scope?: Scope;
 }
-
-const CONSUMER_WORKSPACE = "app";
 
 class NeetoJWT {
   private email: string;

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -1,6 +1,7 @@
 import {
   CLIENT_APPS,
   CONSUMER_LOGIN_PATH,
+  CONSUMER_WORKSPACE,
   NEETO_URL_COMPONENT_REGEX,
   NEETO_URL_PREFIX_REGEX,
   TLD,
@@ -22,9 +23,11 @@ export const getLoginUri = (
   const protocol =
     process.env.NEETO_JWT_ENV === "development" ? "http" : "https";
   const params = new URLSearchParams(searchParams).toString();
-  const path = scope === "consumer" ? CONSUMER_LOGIN_PATH : USER_LOGIN_PATH;
+  const isConsumer = scope === "consumer";
+  const host = isConsumer ? CONSUMER_WORKSPACE : workspace;
+  const path = isConsumer ? CONSUMER_LOGIN_PATH : USER_LOGIN_PATH;
 
-  return `${protocol}://${workspace}${getTopLevelDomain()}${path}?${params}`;
+  return `${protocol}://${host}${getTopLevelDomain()}${path}?${params}`;
 };
 
 export const getTopLevelDomain = () => {

--- a/js/test/index.test.ts
+++ b/js/test/index.test.ts
@@ -152,17 +152,23 @@ describe("NeetoJWT", () => {
     }
   });
 
-  it("should honour an explicit consumer-scope workspace override", () => {
+  it("should send consumer scope to the global app host regardless of workspace override, while preserving the workspace claim", () => {
     const neetoJWT = new NeetoJWT({
       email,
       privateKey,
-      workspace: "staging-app",
+      workspace: "spinkart",
       scope: "consumer",
     });
     const loginUrl = neetoJWT.generateLoginUrl("http://partner.example.com/cb");
     expect(loginUrl).toContain(
-      "https://staging-app.neetoauth.com/consumers/auth/jwt"
+      "https://app.neetoauth.com/consumers/auth/jwt"
     );
+
+    const token = new URL(loginUrl).searchParams.get("jwt") as string;
+    const payload = JSON.parse(
+      Buffer.from(token.split(".")[1], "base64").toString()
+    );
+    expect(payload.workspace).toBe("spinkart");
   });
 
   it("should not double-encode the consumer redirect URI", () => {


### PR DESCRIPTION
Closes #40 