### PR TITLE
Rebase and atomically push commit with tag in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
 
       - name: Setup git user
         run: |
@@ -75,7 +76,7 @@ jobs:
           git fetch origin main
           git rebase origin/main
           git tag -f "v${VERSION}"
-          git push --atomic origin HEAD:main "+refs/tags/v${VERSION}"
+          git push --atomic origin HEAD:main "refs/tags/v${VERSION}"
 
       - name: Publish the package on NPM
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'major') ) }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.RELEASE_PAT }}
 
@@ -30,7 +30,7 @@ jobs:
           git config user.email "neetobot.github@neeto.com"
 
       - name: Setup NodeJS LTS version
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516
+        uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
 
@@ -63,15 +63,19 @@ jobs:
         id: package-version
 
       - name: Create a new version release commit
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           message: "New version release"
+          push: false
 
-      - name: Push the commit to main
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.RELEASE_PAT }}
-          branch: main
+      - name: Rebase on latest main and push commit and tag
+        working-directory: ${{ github.workspace }}
+        run: |
+          VERSION=$(node -p "require('./js/package.json').version")
+          git fetch origin main
+          git rebase origin/main
+          git tag -f "v${VERSION}"
+          git push --atomic origin HEAD:main "+refs/tags/v${VERSION}"
 
       - name: Publish the package on NPM
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'major') ) }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
           git config user.email "neetobot.github@neeto.com"
 
       - name: Setup NodeJS LTS version
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: ".nvmrc"
 
@@ -64,7 +64,7 @@ jobs:
         id: package-version
 
       - name: Create a new version release commit
-        uses: EndBug/add-and-commit@v10
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10
         with:
           message: "New version release"
           push: false


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` and `actions/setup-node` to v5, and `EndBug/add-and-commit` to v10.
- Set `push: false` on `add-and-commit` so the version-bump commit is created locally but not pushed.
- Replace the separate push step with a script that rebases onto latest `origin/main`, creates the `v${VERSION}` tag, and pushes the commit and tag together via `git push --atomic`.

## Why
Pushing the commit and tag in one atomic operation prevents races where `main` advances between the commit and tag pushes, and avoids non-fast-forward failures when other PRs land during the release run.

## Test plan
- [ ] Merge a PR with a release label and confirm the workflow rebases, tags, pushes atomically, and publishes to npm.