### PR TITLE
Fix .neetoci paths filter (supersedes #55)

### DIFF
--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,33 +2,6 @@ version: v1.0
 
 plan: standard-2
 
-paths:
-  - app/**
-  - bin/**
-  - config/**
-  - db/**
-  - lib/**
-  - test/**
-  - .neetoci/default.yml
-  - .neetoci/scripts/run_eslint_on_modified_files.sh
-  - .neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh
-  - .neetoci/scripts/check_schema_drift.sh
-  - Gemfile*
-  - package.json
-  - yarn.lock
-  - Rakefile
-  - .env.test
-  - config.ru
-  - .*.yml
-  - .ruby-version
-  - .node-version
-  - .nvmrc
-  - .active_record_doctor.rb
-  - .prettierrc.js
-  - "*.config.*"
-  - .eslintignore
-  - .eslintrc.js
-
 global_job_config:
   setup:
     - checkout

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,6 +2,12 @@ version: v1.0
 
 plan: standard-2
 
+paths:
+  - js/**
+  - .neetoci/default.yml
+  - .node-version
+  - .nvmrc
+
 global_job_config:
   setup:
     - checkout


### PR DESCRIPTION
## What was wrong

#55 added a generic, copy-pasted `paths:` filter written for a Rails+JS stack (see neetozone/neeto-engineering#1970), including `app/**`, `config/**`, `db/**`, `Gemfile*`, three hardcoded `.neetoci/scripts/*.sh` filenames, and root-level eslint/prettier config. None of this applies here: neeto-jwt's only CI job `cd`s into `js/` and runs `yarn test` (vitest) -- there's no rubocop/eslint/schema-drift step, no Rails app, and no `.neetoci/scripts/` directory in this repo at all.

## What changed

Reverts #55 and re-adds a minimal `paths:` list matching what this CI job actually runs: `js/**` (covers `js/package.json`, `js/tsconfig.json`, `js/src`, `js/test`, `js/yarn.lock`), `.neetoci/default.yml`, `.node-version`, `.nvmrc`. Left out root-level `package.json`/`eslint.config.mjs`, which only back husky/lint-staged pre-commit hooks and aren't touched by this CI job.

Refs neetozone/neeto-engineering#1970